### PR TITLE
Add --youth toggle to commands

### DIFF
--- a/src/games/tests/test_import_games.py
+++ b/src/games/tests/test_import_games.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 from base.tests.model_test_case import ModelTestCase
 from games.models import Game
 from leagues.models import League, Season
+from leagues.tests import test_setup_league
 
 
 class ImportGamesTest(ModelTestCase):
@@ -83,3 +84,22 @@ class Forfeit(ModelTestCase):
         self.assertEqual(game.home_goals, 0)
         self.assertEqual(game.guest_goals, 0)
         self.assertEqual(game.forfeiting_team, game.guest_team)
+
+
+class Youth(ModelTestCase):
+    def test_youth(self):
+        test_setup_league.Youth.test_youth(self)
+
+        return_code = call_command('import_games', '--youth')
+        self.assertEqual(return_code, None)
+
+        league: League = self.assert_objects(League)
+        self.assertGreater(league.game_set.count(), 0)
+
+    def test_no_youth(self):
+        test_setup_league.Youth.test_youth(self)
+
+        return_code = call_command('import_games')
+        self.assertEqual(return_code, None)
+
+        self.assert_objects(Game, count=0)

--- a/src/leagues/management/commands/setup.py
+++ b/src/leagues/management/commands/setup.py
@@ -21,15 +21,16 @@ class Command(BaseCommand):
     processed_districts: set = set()
 
     def add_arguments(self, parser):
-        parser.add_argument('--youth', action='store_true', help="Include youth teams in setup.")
-        parser.add_argument(
-            '--associations', '-a', nargs='+', type=int, metavar='orgGrpID', help="IDs of Associations to be setup.")
-        parser.add_argument(
-            '--districts', '-d', nargs='+', type=int, metavar='orgID', help="IDs of Districts to be setup.")
-        parser.add_argument(
-            '--seasons', '-s', nargs='+', type=int, metavar='start_year', help="Start Years of Seasons to be setup.")
-        parser.add_argument(
-            '--leagues', '-l', nargs='+', type=int, metavar='score', help="IDs of Leagues to be setup.")
+        parser.add_argument('--associations', '-a', nargs='+', type=int, metavar='orgGrpID',
+                            help="IDs of Associations.")
+        parser.add_argument('--districts', '-d', nargs='+', type=int, metavar='orgID',
+                            help="IDs of Districts.")
+        parser.add_argument('--seasons', '-s', nargs='+', type=int, metavar='start year',
+                            help="Start Years of Seasons.")
+        parser.add_argument('--leagues', '-l', nargs='+', type=int, metavar='score/sGID',
+                            help="IDs of Leagues.")
+        parser.add_argument('--youth', action='store_true',
+                            help="Include youth leagues.")
 
     def handle(self, *args, **options):
         self.options = options
@@ -137,7 +138,7 @@ class Command(BaseCommand):
 
         name = parsing.parse_league_name(dom)
 
-        if League.is_youth_league(name) and not self.options['youth']:
+        if League.is_youth_league(abbreviation) and not self.options['youth']:
             LOGGER.debug('SKIPPING League (youth league): %s %s', bhv_id, name)
             return
 

--- a/src/leagues/models.py
+++ b/src/leagues/models.py
@@ -40,9 +40,14 @@ class League(models.Model):
     def source_url(self):
         return self.build_source_url(self.bhv_id)
 
+    @property
+    def youth(self) -> bool:
+        return self.is_youth_league(self.abbreviation)
+
     @staticmethod
-    def is_youth_league(name):
-        return re.search('MJ', name) \
-            or re.search('WJ', name) \
-            or re.search('Jugend', name) \
-            or re.search('Mini', name)
+    def is_youth_league(abbreviation: str) -> bool:
+        ret = re.search('mJ', abbreviation) \
+            or re.search('wJ', abbreviation) \
+            or re.search('Jugend', abbreviation) \
+            or re.search('Mini', abbreviation)
+        return bool(ret)

--- a/src/leagues/tests/test_setup_league.py
+++ b/src/leagues/tests/test_setup_league.py
@@ -79,3 +79,18 @@ class SetupTest(ModelTestCase):
 
         self.assertEqual(mkl21.name, "Männer Kreisliga 2-1")
         self.assertEqual(mkl22.name, "Männer Kreisliga 2-2")
+
+
+class Youth(ModelTestCase):
+    def test_youth(self):
+        return_code = call_command('setup', '-a', 35, '-d', 35, '-s', 2019, '-l', 46921, '--youth')
+        self.assertEqual(return_code, None)
+
+        league: League = self.assert_objects(League)
+        self.assertTrue(league.youth)
+
+    def test_no_youth(self):
+        return_code = call_command('setup', '-a', 35, '-d', 35, '-s', 2019, '-l', 46921)
+        self.assertEqual(return_code, None)
+
+        self.assert_objects(League, count=0)

--- a/src/players/management/commands/import_reports.py
+++ b/src/players/management/commands/import_reports.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
             LOGGER.debug('SKIPPING Report (ignore list): %s - %s', game.report_number, game)
         elif game.home_team.retirement is not None or game.guest_team.retirement is not None:
             if game.score_set.count() > 0:
-                LOGER.info('DELETING Game Scores (retired team): %s - %s', game.report_number, game)
+                LOGGER.info('DELETING Game Scores (retired team): %s - %s', game.report_number, game)
                 game.score_set.all().delete()
             else:
                 LOGGER.debug('SKIPPING Game (retired team): %s - %s', game.report_number, game)

--- a/src/players/management/commands/import_reports.py
+++ b/src/players/management/commands/import_reports.py
@@ -19,7 +19,7 @@ from teams.models import Team
 from . import parse_report
 from .fetch_report import fetch_report
 
-LOGER = logging.getLogger('hbscorez')
+LOGGER = logging.getLogger('hbscorez')
 
 
 class Command(BaseCommand):
@@ -27,20 +27,22 @@ class Command(BaseCommand):
     bugged_reports = [450001, 473097, 497475, 501159, 546059, 562543, 567811, 572051, 598812, 627428, 638260]
 
     def add_arguments(self, parser):
+        parser.add_argument('--associations', '-a', nargs='+', type=int, metavar='orgGrpID',
+                            help="IDs of Associations.")
+        parser.add_argument('--districts', '-d', nargs='+', type=int, metavar='orgID',
+                            help="IDs of Districts.")
+        parser.add_argument('--seasons', '-s', nargs='+', type=int, metavar='start year',
+                            help="Start Years of Seasons.")
+        parser.add_argument('--leagues', '-l', nargs='+', type=int, metavar='score/sGID',
+                            help="IDs of Leagues.")
+        parser.add_argument('--youth', action='store_true',
+                            help="Include youth leagues.")
+        parser.add_argument('--games', '-g', nargs='+', type=int, metavar='game number',
+                            help="numbers of Games.")
+        parser.add_argument('--skip-games', '-G', nargs='+', type=int, metavar='game number',
+                            help="numbers of Games.")
         parser.add_argument('--force-update', '-f', action='store_true',
                             help='force download and overwrite if report already exists')
-        parser.add_argument('--associations', '-a', nargs='+', type=int, metavar='orgGrpID',
-                            help="orgGrpIDs of Associations whose games reports shall be downloaded.")
-        parser.add_argument('--districts', '-d', nargs='+', type=int, metavar='orgID',
-                            help="orgIDs of Districts whose games reports shall be downloaded.")
-        parser.add_argument('--seasons', '-s', nargs='+', type=int, metavar='start_year',
-                            help="Start Years of Seasons to be setup.")
-        parser.add_argument('--leagues', '-l', nargs='+', type=int, metavar='score',
-                            help="sGIDs of Leagues whose games reports shall be downloaded.")
-        parser.add_argument('--games', '-g', nargs='+', type=int, metavar='game number',
-                            help="numbers of Games whose reports shall be downloaded.")
-        parser.add_argument('--skip-games', '-G', nargs='+', type=int, metavar='game number',
-                            help="numbers of Games whose reports shall not be downloaded.")
 
     def handle(self, *args, **options):
         self.options = options
@@ -55,7 +57,7 @@ class Command(BaseCommand):
 
     def import_association(self, association):
         if self.options['associations'] and association.bhv_id not in self.options['associations']:
-            LOGER.debug('SKIPPING Association: %s (options)', association)
+            LOGGER.debug('SKIPPING Association: %s (options)', association)
             return
 
         for district in association.district_set.all():
@@ -63,7 +65,7 @@ class Command(BaseCommand):
 
     def import_district(self, district):
         if self.options['districts'] and district.bhv_id not in self.options['districts']:
-            LOGER.debug('SKIPPING District: %s (options)', district)
+            LOGGER.debug('SKIPPING District: %s (options)', district)
             return
 
         season_pks = district.league_set.values('season').distinct()
@@ -73,7 +75,7 @@ class Command(BaseCommand):
 
     def import_district_season(self, district, season):
         if self.options['seasons'] and season.start_year not in self.options['seasons']:
-            LOGER.debug('SKIPPING District Season: %s %s (options)', district, season)
+            LOGGER.debug('SKIPPING District Season: %s %s (options)', district, season)
             return
 
         for league in district.league_set.filter(season=season):
@@ -81,7 +83,11 @@ class Command(BaseCommand):
 
     def import_league(self, league):
         if self.options['leagues'] and league.bhv_id not in self.options['leagues']:
-            LOGER.debug('SKIPPING League: %s (options)', league)
+            LOGGER.debug('SKIPPING League: %s (options)', league)
+            return
+
+        if league.youth:
+            LOGGER.debug('SKIPPING League (youth league): %s', league)
             return
 
         for game in league.game_set.all():
@@ -89,28 +95,28 @@ class Command(BaseCommand):
 
     def import_game(self, game: Game):
         if self.options['games'] and game.number not in self.options['games']:
-            LOGER.debug('SKIPPING Game (options): %s - %s', game.report_number, game)
+            LOGGER.debug('SKIPPING Game (options): %s - %s', game.report_number, game)
         elif game.report_number is None:
-            LOGER.debug('SKIPPING Game (no report): %s - %s', game.report_number, game)
+            LOGGER.debug('SKIPPING Game (no report): %s - %s', game.report_number, game)
         elif game.report_number in self.bugged_reports:
-            LOGER.debug('SKIPPING Report (ignore list): %s - %s', game.report_number, game)
+            LOGGER.debug('SKIPPING Report (ignore list): %s - %s', game.report_number, game)
         elif game.home_team.retirement is not None or game.guest_team.retirement is not None:
             if game.score_set.count() > 0:
                 LOGER.info('DELETING Game Scores (retired team): %s - %s', game.report_number, game)
                 game.score_set.all().delete()
             else:
-                LOGER.debug('SKIPPING Game (retired team): %s - %s', game.report_number, game)
+                LOGGER.debug('SKIPPING Game (retired team): %s - %s', game.report_number, game)
         elif game.score_set.count() > 0:
             if not self.options['force_update']:
-                LOGER.debug('SKIPPING Game (existing scores): %s - %s', game.report_number, game)
+                LOGGER.debug('SKIPPING Game (existing scores): %s - %s', game.report_number, game)
             else:
-                LOGER.info('REIMPORTING Report: %s - %s', game.report_number, game)
+                LOGGER.info('REIMPORTING Report: %s - %s', game.report_number, game)
                 game.score_set.all().delete()
                 import_report(game)
         elif game.forfeiting_team is not None:
-            LOGER.debug('SKIPPING Game (forfeit): %s - %s', game.report_number, game)
+            LOGGER.debug('SKIPPING Game (forfeit): %s - %s', game.report_number, game)
         else:
-            LOGER.info('IMPORTING Report: %s - %s', game.report_number, game)
+            LOGGER.info('IMPORTING Report: %s - %s', game.report_number, game)
             import_report(game)
 
 
@@ -118,7 +124,7 @@ class Command(BaseCommand):
 def import_report(game: Game):
     response = fetch_report(game)
     if int(response.headers.get('Content-Length', default=-1)) == 0:
-        LOGER.warning('SKIPPING Report (empty file): %s - %s', game.report_number, game)
+        LOGGER.warning('SKIPPING Report (empty file): %s - %s', game.report_number, game)
         return
 
     game.report_path().write_bytes(response.content)
@@ -147,18 +153,18 @@ def import_scores(table, game: Game, team: Team):
         if not player_number and not player_name:
             return
         if player_number in ('A', 'B', 'C', 'D'):
-            LOGER.debug('SKIPPING Score (coach): %s - %s', player_number, player_name)
+            LOGGER.debug('SKIPPING Score (coach): %s - %s', player_number, player_name)
             return
         if not player_number:
-            LOGER.warning('SKIPPING Score (no player number): %s', player_name)
+            LOGGER.warning('SKIPPING Score (no player number): %s', player_name)
             return
         if not player_name:
-            LOGER.warning('SKIPPING Score (no player name): %s', player_number)
+            LOGGER.warning('SKIPPING Score (no player name): %s', player_number)
             return
         try:
             int(player_number)
         except ValueError as err:
-            LOGER.exception('invalid Score (invalid player number): %s - %s\n%s', player_number, player_name, err)
+            LOGGER.exception('invalid Score (invalid player number): %s - %s\n%s', player_number, player_name, err)
             return
 
         player = Player(name=player_name, team=team)
@@ -176,7 +182,7 @@ def parse_score(player: Player, game: Game, row_data) -> Score:
             goals = int(goals_str)
         except ValueError as err:
             goals = 0
-            LOGER.exception('invalid Score goals: %s - %s - %s\n%s', player_number, player.name, goals, err)
+            LOGGER.exception('invalid Score goals: %s - %s - %s\n%s', player_number, player.name, goals, err)
     penalty_tries, penalty_goals = parsing.parse_penalty_data(row_data[6])
 
     return Score(player=player, player_number=int(row_data[0]), game=game, goals=goals,

--- a/src/players/tests/test_import_reports.py
+++ b/src/players/tests/test_import_reports.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock, patch
 from django.core.management import call_command
 
 from base.tests.model_test_case import ModelTestCase
+from games.tests import test_import_games
+from players.models import Player, Score
 
 
 class Forfeit(ModelTestCase):
@@ -19,3 +21,14 @@ class Forfeit(ModelTestCase):
             return_code = call_command('import_reports')
             self.assertEqual(return_code, None)
             mock.assert_not_called()
+
+
+class Youth(ModelTestCase):
+    def test_youth(self):
+        test_import_games.Youth.test_youth(self)
+
+        return_code = call_command('import_reports')
+        self.assertEqual(return_code, None)
+
+        self.assert_objects(Score, count=0)
+        self.assert_objects(Player, count=0)


### PR DESCRIPTION
# Change Types
<!--- What type of changes does your code introduce? Put an `x` in one of the box that applies -->
<!--- If multiple items apply, consider creating a seperate pull request for each -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Provide a general summary of your changes in the Title above -->
# Description
This PR adds a command toggle to `import_games` and `import_reports` for including youth Leagues.
That allows the application admin to process specific youth data:
* import youth Leagues and Teams without importing youth games
* import youth Games without importing youth Scores ❗️ 

# Alternative
I could have turned on the `--youth` toggle by default for `setup` and `import_games`, since those commands don't process personal data.
I decided not to implement this, since it would have made this PR's scope much larger and would change default behavour.

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read [CONTRIBUTING.md](/djbrown/hbscorez/blob/master/.github/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] My tests run automatically.
- [x] All new and existing tests passed.
